### PR TITLE
Update Dockerfile

### DIFF
--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -1,4 +1,4 @@
-FROM balabit/syslog-ng:3.14.1
+FROM 056154071827.dkr.ecr.us-east-1.amazonaws.com/syslog-ng:latest
 MAINTAINER dpt <hart-ds-dpt@uscm.org>
 
 # fluentd

--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -1,4 +1,4 @@
-FROM 056154071827.dkr.ecr.us-east-1.amazonaws.com/syslog-ng:latest
+FROM 056154071827.dkr.ecr.us-east-1.amazonaws.com/syslog-fluentd:latest
 MAINTAINER dpt <hart-ds-dpt@uscm.org>
 
 # fluentd


### PR DESCRIPTION
Hi @twinge,

Production syslog-ng containers were failing due to pulling from dockerhub, not ecr.
This change should fix that.